### PR TITLE
Fix STM32F7 support

### DIFF
--- a/canard.cpp
+++ b/canard.cpp
@@ -34,7 +34,7 @@ volatile int allTimeMaxTxSize;
 volatile int maxRxSize;
 volatile int maxTxSize;
 
-#if defined(STM32F0) || defined(STM32F3)
+#if defined(STM32F0) || defined(STM32F3) || defined(STM32F7)
 void USED CAN_IT_Callback() {
     if (!CAN_RX_RB.is_full()) {
         canardSTM32Receive(&CAN_RX_RB.get_next_write_entry());

--- a/drivers/stm32/canard_stm32.c
+++ b/drivers/stm32/canard_stm32.c
@@ -27,18 +27,18 @@ static bool g_abort_tx_on_error = false;
 void CAN_RX0_IRQHandler(void) {
     extern void CAN_IT_Callback();
 
-    if ((CAN->IER & CAN_IER_FMPIE0) && (CAN->RF0R & 0x3)) {
+    if ((BXCAN->IER & CAN_IER_FMPIE0) && (BXCAN->RF0R & 0x3)) {
         CAN_IT_Callback();
 
     } else {
-        if ((CAN->ESR & CAN_ESR_LEC) && (CAN->IER & CAN_IER_LECIE) && (CAN->IER & CAN_IER_ERRIE)) {
+        if ((BXCAN->ESR & CAN_ESR_LEC) && (BXCAN->IER & CAN_IER_LECIE) && (BXCAN->IER & CAN_IER_ERRIE)) {
             /* TODO FE-5184 See if this is necessary */
             /* Canard is supposed to handle error codes but we may have a leftover one at startup. */
 
-            CAN->ESR &= ~CAN_ESR_LEC;
+            BXCAN->ESR &= ~CAN_ESR_LEC;
         }
 
-        CAN->MSR |= CAN_MSR_ERRI;
+        BXCAN->MSR |= CAN_MSR_ERRI;
     }
 }
 
@@ -46,24 +46,24 @@ void CAN_TX_IRQHandler(void) {
     extern void processTxQueue();
 
     /* Check End of transmission flag */
-    if ((CAN->IER & CAN_IER_TMEIE) == CAN_IER_TMEIE)
+    if ((BXCAN->IER & CAN_IER_TMEIE) == CAN_IER_TMEIE)
     {
         /* Check Transmit request completion status */
-        if ((((CAN->TSR) & (CAN_TSR_RQCP0 | CAN_TSR_TXOK0 | CAN_TSR_TME0)) == (CAN_TSR_RQCP0 | CAN_TSR_TXOK0 | CAN_TSR_TME0))
-            || (((CAN->TSR) & (CAN_TSR_RQCP1 | CAN_TSR_TXOK1 | CAN_TSR_TME1)) == (CAN_TSR_RQCP1 | CAN_TSR_TXOK1 | CAN_TSR_TME1))
-            || (((CAN->TSR) & (CAN_TSR_RQCP2 | CAN_TSR_TXOK2 | CAN_TSR_TME2)) == (CAN_TSR_RQCP2 | CAN_TSR_TXOK2 | CAN_TSR_TME2)))
+        if ((((BXCAN->TSR) & (CAN_TSR_RQCP0 | CAN_TSR_TXOK0 | CAN_TSR_TME0)) == (CAN_TSR_RQCP0 | CAN_TSR_TXOK0 | CAN_TSR_TME0))
+            || (((BXCAN->TSR) & (CAN_TSR_RQCP1 | CAN_TSR_TXOK1 | CAN_TSR_TME1)) == (CAN_TSR_RQCP1 | CAN_TSR_TXOK1 | CAN_TSR_TME1))
+            || (((BXCAN->TSR) & (CAN_TSR_RQCP2 | CAN_TSR_TXOK2 | CAN_TSR_TME2)) == (CAN_TSR_RQCP2 | CAN_TSR_TXOK2 | CAN_TSR_TME2)))
         {
             /* Check Transmit success */
-            if ((((CAN->TSR) & CAN_TSR_TXOK0) != CAN_TSR_TXOK0)
-                && (((CAN->TSR) & CAN_TSR_TXOK1) != CAN_TSR_TXOK1)
-                && (((CAN->TSR) & CAN_TSR_TXOK2) != CAN_TSR_TXOK2))  /* Transmit failure */
+            if ((((BXCAN->TSR) & CAN_TSR_TXOK0) != CAN_TSR_TXOK0)
+                && (((BXCAN->TSR) & CAN_TSR_TXOK1) != CAN_TSR_TXOK1)
+                && (((BXCAN->TSR) & CAN_TSR_TXOK2) != CAN_TSR_TXOK2))  /* Transmit failure */
             {
                 /* Set CAN error code to TXFAIL error */
                 canard_errors.tx_errors++;
             }
 
             /* Clear transmission status flags (RQCPx and TXOKx) */
-            CAN->TSR |= CAN_TSR_RQCP0  | CAN_TSR_RQCP1  | CAN_TSR_RQCP2 | CAN_TSR_TXOK0 | CAN_TSR_TXOK1 | CAN_TSR_TXOK2;
+            BXCAN->TSR |= CAN_TSR_RQCP0  | CAN_TSR_RQCP1  | CAN_TSR_RQCP2 | CAN_TSR_TXOK0 | CAN_TSR_TXOK1 | CAN_TSR_TXOK2;
 
             processTxQueue();
         }

--- a/drivers/stm32/canard_stm32.h
+++ b/drivers/stm32/canard_stm32.h
@@ -30,6 +30,12 @@
 #define CANARD_TX_IRQn CAN_TX_IRQn
 #endif
 
+#ifdef STM32F745xx
+#include <stm32f745xx.h>
+#define CANARD_RX0_IRQn CAN1_RX0_IRQn
+#define CANARD_TX_IRQn CAN1_TX_IRQn
+#endif
+
 #ifdef STM32F0
 #include <stm32f0xx.h>
 #define CANARD_RX0_IRQn CEC_CAN_IRQn


### PR DESCRIPTION
The F7 doesn't have a peripheral named `CAN`, since it's got both `CAN1` and `CAN2`.  This switches to using `BXCAN` consistently, and adds a new include for the F7.